### PR TITLE
Adding a prefix when date is uncertain

### DIFF
--- a/config/locales/de.edtf.yml
+++ b/config/locales/de.edtf.yml
@@ -46,6 +46,7 @@ de:
       set_later_prefix_inclusive: "nach "
       set_two_dates_connector_exclusive: " oder "
       set_two_dates_connector_inclusive: " eund "
+      uncertain_date_prefix: ""
       uncertain_date_suffix: " ?"
       unknown: "Datum unbekannt"
       unspecified_digit_substitute: "x"

--- a/config/locales/en.edtf.yml
+++ b/config/locales/en.edtf.yml
@@ -35,6 +35,7 @@ en:
       set_later_prefix_inclusive: 'on and after '
       set_two_dates_connector_exclusive: " or "
       set_two_dates_connector_inclusive: " and "
+      uncertain_date_prefix: ""
       uncertain_date_suffix: "?"
       unknown: 'unknown'
       unspecified_digit_substitute: "x"

--- a/config/locales/fr.edtf.yml
+++ b/config/locales/fr.edtf.yml
@@ -46,6 +46,7 @@ fr:
       set_later_prefix_inclusive: 'Le et après '
       set_two_dates_connector_exclusive: " ou "
       set_two_dates_connector_inclusive: " et "
+      uncertain_date_prefix: ""
       uncertain_date_suffix: "?"
       unknown: 'Inconnue'
       unspecified_digit_substitute: "x"

--- a/config/locales/it.edtf.yml
+++ b/config/locales/it.edtf.yml
@@ -46,6 +46,7 @@ it:
       set_later_prefix_inclusive: "dopo "
       set_two_dates_connector_exclusive: " o "
       set_two_dates_connector_inclusive: " e "
+      uncertain_date_prefix: ""
       uncertain_date_suffix: " ?"
       unknown: "data sconosciuta"
       unspecified_digit_substitute: "x"

--- a/lib/edtf/humanize/language/default/formats.rb
+++ b/lib/edtf/humanize/language/default/formats.rb
@@ -10,7 +10,7 @@ module Edtf
           private
 
           def date_format(date)
-            "#{apply_if_unspecified_year(date)}#{apply_if_uncertain(date)}"
+            "#{apply_prefix_if_uncertain(date)}#{apply_if_unspecified_year(date)}#{apply_suffix_if_uncertain(date)}"
           end
 
           def date_precision(date)
@@ -85,10 +85,17 @@ module Edtf
           end
 
           # '1990?' => 1990?
-          def apply_if_uncertain(date)
+          def apply_suffix_if_uncertain(date)
             return '' unless date.respond_to?(:uncertain?) && date.uncertain?
 
             I18n.t('edtf.terms.uncertain_date_suffix', default: '?')
+          end
+
+          # '1990?' => ?1990
+          def apply_prefix_if_uncertain(date)
+            return '' unless date.respond_to?(:uncertain?) && date.uncertain?
+
+            I18n.t('edtf.terms.uncertain_date_prefix', default: '')
           end
 
           # '198u' => 198x

--- a/lib/edtf/humanize/language/default/season.rb
+++ b/lib/edtf/humanize/language/default/season.rb
@@ -10,10 +10,11 @@ module Edtf
           extend self
 
           def humanizer(date)
-            "#{apply_prefix_if_approximate(date)}" \
+            "#{apply_prefix_if_uncertain(date)}" \
+              "#{apply_prefix_if_approximate(date)}" \
               "#{translate_season(date.season)} #{date.year}" \
               "#{apply_suffix_if_approximate(date)}" \
-              "#{apply_if_uncertain(date)}"
+              "#{apply_suffix_if_uncertain(date)}"
           end
 
           private


### PR DESCRIPTION
For uncertain dates, we'd like to support displaying something like, "possibly 2002". Approximate dates have a prefix and suffix, so I followed that example. I am not sure what the best way to test this is, let me know if you have any advice on that front. Thanks!