### PR TITLE
Loosening Ruby requirement to include Ruby 2.3

### DIFF
--- a/edtf-humanize.gemspec
+++ b/edtf-humanize.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
                   'EDTF::Interval, EDTF::Set, EDTF::Season, EDTF::Unknown, ' \
                   'and Date (ISO 8601 compliant) objects.'
   s.license     = 'BSD-3-Clause'
-  s.required_ruby_version = '>= 2.4', '< 4'
+  s.required_ruby_version = '>= 2.3', '< 4'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE.txt', 'README.rdoc']
 


### PR DESCRIPTION
Sadly, I have to maintain a Ruby 2.3 app and I was wondering if we could loose then Ruby requirement for this gem, or if there was a strong reason it could only support Ruby 2.4. `ruby-edtf` [seems to support Ruby 2.1+](https://github.com/inukshuk/edtf-ruby?tab=readme-ov-file#compatibility). I tested this gem in my Ruby 2.3 app and it works fine. I totally understand if this change is not palatable! We are looking to upgrade our app in the very near feature, so I can just keep a forked version in the meanwhile.