### PR TITLE
Support unknown intervals

### DIFF
--- a/config/locales/de.edtf.yml
+++ b/config/locales/de.edtf.yml
@@ -48,6 +48,12 @@ de:
       set_two_dates_connector_inclusive: " eund "
       uncertain_date_suffix: " ?"
       unknown: "Datum unbekannt"
+      unknown_start_interval_with_day: "unbekanntes Datum bis %{date}"
+      unknown_start_interval_with_month: "unbekanntes Datum bis %{date}"
+      unknown_start_interval_with_year: "unbekanntes Datum bis %{date}"
+      unknown_end_interval_with_day: "%{date} bis unbekanntes Datum"
+      unknown_end_interval_with_month: "%{date} bis unbekanntes Datum"
+      unknown_end_interval_with_year: "%{date} bis unbekanntes Datum"
       unspecified_digit_substitute: "x"
     formats:
       day_precision_strftime_format: "%-d. %B %Y"

--- a/config/locales/de.edtf.yml
+++ b/config/locales/de.edtf.yml
@@ -25,7 +25,6 @@ de:
       interval_prefix_month: ""
       interval_prefix_year: ""
       interval_connector_approximate: " - "
-      interval_connector_open: " - "
       interval_connector_day: " - "
       interval_connector_month: " - "
       interval_connector_year: " - "

--- a/config/locales/en.edtf.yml
+++ b/config/locales/en.edtf.yml
@@ -37,6 +37,12 @@ en:
       set_two_dates_connector_inclusive: " and "
       uncertain_date_suffix: "?"
       unknown: 'unknown'
+      unknown_start_interval_with_day: "unknown date to %{date}"
+      unknown_start_interval_with_month: "unknown month to %{date}"
+      unknown_start_interval_with_year: "unknown year to %{date}"
+      unknown_end_interval_with_day: "%{date} to unknown date"
+      unknown_end_interval_with_month: "%{date} to unknown month"
+      unknown_end_interval_with_year: "%{date} to unknown year"
       unspecified_digit_substitute: "x"
     formats:
       day_precision_strftime_format: "%B %-d, %Y"

--- a/config/locales/en.edtf.yml
+++ b/config/locales/en.edtf.yml
@@ -15,7 +15,6 @@ en:
       interval_prefix_year: ""
       interval_connector_approximate: " to "
       interval_connector_day: " to "
-      interval_connector_open: " to "
       interval_connector_month: " to "
       interval_connector_year: " to "
       interval_unspecified_suffix: "s"

--- a/config/locales/fr.edtf.yml
+++ b/config/locales/fr.edtf.yml
@@ -25,7 +25,6 @@ fr:
       interval_prefix_month: "De "
       interval_prefix_year: "De "
       interval_connector_approximate: " à "
-      interval_connector_open: " à "
       interval_connector_day: " au "
       interval_connector_month: " à "
       interval_connector_year: " à "

--- a/config/locales/fr.edtf.yml
+++ b/config/locales/fr.edtf.yml
@@ -48,6 +48,12 @@ fr:
       set_two_dates_connector_inclusive: " et "
       uncertain_date_suffix: "?"
       unknown: 'Inconnue'
+      unknown_start_interval_with_day: "date inconnue à %{date}"
+      unknown_start_interval_with_month: "date inconnue à %{date}"
+      unknown_start_interval_with_year: "date inconnue à %{date}"
+      unknown_end_interval_with_day: "%{date} à une date inconnue"
+      unknown_end_interval_with_month: "%{date} à une date inconnue"
+      unknown_end_interval_with_year: "%{date} à une date inconnue"
       unspecified_digit_substitute: "x"
     formats:
       day_precision_strftime_format: "%-d %B %Y"

--- a/config/locales/it.edtf.yml
+++ b/config/locales/it.edtf.yml
@@ -48,6 +48,12 @@ it:
       set_two_dates_connector_inclusive: " e "
       uncertain_date_suffix: " ?"
       unknown: "data sconosciuta"
+      unknown_start_interval_with_day: "data sconosciuta a %{date}"
+      unknown_start_interval_with_month: "data sconosciuta a %{date}"
+      unknown_start_interval_with_year: "data sconosciuta a %{date}"
+      unknown_end_interval_with_day: "%{date} a data sconosciuta"
+      unknown_end_interval_with_month: "%{date} a data sconosciuta"
+      unknown_end_interval_with_year: "%{date} a data sconosciuta"
       unspecified_digit_substitute: "x"
     formats:
       day_precision_strftime_format: "%-d %B %Y"

--- a/config/locales/it.edtf.yml
+++ b/config/locales/it.edtf.yml
@@ -25,7 +25,6 @@ it:
       interval_prefix_month: ""
       interval_prefix_year: ""
       interval_connector_approximate: " - "
-      interval_connector_open: " - "
       interval_connector_day: " - "
       interval_connector_month: " - "
       interval_connector_year: " - "

--- a/lib/edtf/humanize/language/default/interval.rb
+++ b/lib/edtf/humanize/language/default/interval.rb
@@ -12,6 +12,8 @@ module Edtf
           def humanizer(date)
             if date.from == :open || date.to == :open
               open_interval(date)
+            elsif date.from == :unknown || date.to == :unknown
+              unknown_interval(date)
             else
               "#{interval_prefix(date)}" \
                 "#{formatted_date(date.from)}" \
@@ -65,6 +67,52 @@ module Edtf
               I18n.t('edtf.terms.open_end_interval_with_day',
                      date: formatted_date,
                      default: "since #{formatted_date}")
+            end
+          end
+
+          def unknown_interval(date)
+            if date.from == :unknown
+              unknown_start_interval(formatted_date: formatted_date(date.to),
+                                     precision: date.to.precision)
+            elsif date.to == :unknown
+              unknown_end_interval(formatted_date: formatted_date(date.from),
+                                   precision: date.from.precision)
+            end
+          end
+
+          # unknown/1980 => unknown year to 1980
+          def unknown_start_interval(formatted_date:, precision:)
+            case precision
+            when :year
+              I18n.t('edtf.terms.unknown_start_interval_with_year',
+                     date: formatted_date,
+                     default: "unknown year to #{formatted_date}")
+            when :month
+              I18n.t('edtf.terms.unknown_start_interval_with_month',
+                     date: formatted_date,
+                     default: "unknown month to #{formatted_date}")
+            when :day
+              I18n.t('edtf.terms.unknown_start_interval_with_day',
+                     date: formatted_date,
+                     default: "unknown date to #{formatted_date}")
+            end
+          end
+
+          # 1980/unknown => 1980 to unknown year
+          def unknown_end_interval(formatted_date:, precision:)
+            case precision
+            when :year
+              I18n.t('edtf.terms.unknown_end_interval_with_year',
+                     date: formatted_date,
+                     default: "#{formatted_date} to unknown year")
+            when :month
+              I18n.t('edtf.terms.open_end_interval_with_month',
+                     date: formatted_date,
+                     default: "#{formatted_date} to unknown month")
+            when :day
+              I18n.t('edtf.terms.open_end_interval_with_day',
+                     date: formatted_date,
+                     default: "#{formatted_date} to unknown date")
             end
           end
 

--- a/lib/edtf/humanize/language/default/interval.rb
+++ b/lib/edtf/humanize/language/default/interval.rb
@@ -134,17 +134,11 @@ module Edtf
           end
 
           def interval_connector(date)
-            return interval_connector_open if date.to == :open
-
             return interval_connector_approx if date.to.approximate.day ||
                                                 date.to.approximate.month ||
                                                 date.to.approximate.year
 
             interval_connector_other(date)
-          end
-
-          def interval_connector_open
-            I18n.t('edtf.terms.interval_connector_open')
           end
 
           def interval_connector_approx

--- a/spec/edtf/humanize_de_spec.rb
+++ b/spec/edtf/humanize_de_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Edtf::Humanize do
     end
   end
 
+  context 'with an unknown interval start' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('unknown/1970').humanize).to eq('unbekanntes Datum bis 1970')
+    end
+  end
+
+  context 'with an unknown interval end' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('1970/unknown').humanize).to eq('1970 bis unbekanntes Datum')
+    end
+  end
+
   context 'with an approximate interval'
   it 'returns a humanized approximate interval string' do
     expect(Date.edtf('1970~/1980~').humanize).to(

--- a/spec/edtf/humanize_en_spec.rb
+++ b/spec/edtf/humanize_en_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Edtf::Humanize do
     end
   end
 
+  context 'with an unknown interval start' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('unknown/1970').humanize).to eq('unknown year to 1970')
+    end
+  end
+
+  context 'with an unknown interval end' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('1970/unknown').humanize).to eq('1970 to unknown year')
+    end
+  end
+
   context 'with an approximate interval'
   it 'returns a humanized approximate interval string' do
     expect(Date.edtf('1970~/1980~').humanize).to(

--- a/spec/edtf/humanize_fr_spec.rb
+++ b/spec/edtf/humanize_fr_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Edtf::Humanize do
     end
   end
 
+  context 'with an unknown interval start' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('unknown/1970').humanize).to eq('date inconnue à 1970')
+    end
+  end
+
+  context 'with an unknown interval end' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('1970/unknown').humanize).to eq('1970 à une date inconnue')
+    end
+  end
+
   context 'with an approximate interval'
   it 'returns a humanized approximate interval string' do
     expect(Date.edtf('1970~/1980~').humanize).to(

--- a/spec/edtf/humanize_it_spec.rb
+++ b/spec/edtf/humanize_it_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Edtf::Humanize do
     end
   end
 
+  context 'with an unknown interval start' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('unknown/1970').humanize).to eq('data sconosciuta a 1970')
+    end
+  end
+
+  context 'with an unknown interval end' do
+    it 'returns a humanized interval string' do
+      expect(Date.edtf('1970/unknown').humanize).to eq('1970 a data sconosciuta')
+    end
+  end
+
   context 'with an approximate interval'
   it 'returns a humanized approximate interval string' do
     expect(Date.edtf('1970~/1980~').humanize).to(


### PR DESCRIPTION
`ruby-edtf` supports intervals with unknown starts and ends. Currently, this gem throws errors when using intervals with unknown starts or endings. 

This MR adds support for intervals with unknown starts and ends in the same way that open starts and ends are supported. I tried an alternate implementation, but I think this solution provides the most flexibility.  I added the translations for other languages by using Google translate.

Additionally, this MR removes the translation for `interval_connector_open` and its related code because it is not used when creating a human readable string for open intervals. 

Thanks again!